### PR TITLE
eslint settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,8 @@
         "react/jsx-filename-extension": [1, { "extensions": [".js"] }],
         "react/prefer-stateless-function": 0,
         "indent": [1, 4],
-        "react/jsx-indent": [1, 4]
+        "react/jsx-indent": [1, 4],
+        "react/jsx-indent-props": [1, 4],
+        "curly": [2, "all"]
     }
 }


### PR DESCRIPTION
изменения в линтинге:
1) фигурные скобки обязательны даже для однострочных блоков кода.
2) отступы для пропсов в jsx разметке теперь 4 вместо прошлых 2 (теперь все отступы: 4).

Добавил всех в реквест, чтобы были в курсе. через день смержу.