### PR TITLE
Spaced repetition simplified 

### DIFF
--- a/src/services/spacedRepetition.js
+++ b/src/services/spacedRepetition.js
@@ -1,33 +1,33 @@
-const millisecondsPerDay = 1000 * 60 * 60 * 24;
-const powerIndexGood = 1.4;
-const powerIndexEasy = 1.6;
+const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
+const POWER_INDEX_GOOD = 1.4;
+const POWER_INDEX_EASY = 1.6;
 
 export const getMemoInfo = (difficulty, prevRepetitions) => {
-    const currentDateSTamp = Date.now();
+    const currentDateStamp = Date.now();
     const result = {
         repetitions: prevRepetitions ? prevRepetitions + 1 : 1,
-        prevRepetitionDate: currentDateSTamp,
-        nextRepetitionDate: currentDateSTamp,
+        prevRepetitionDate: currentDateStamp,
+        nextRepetitionDate: currentDateStamp,
     };
 
     switch (difficulty) {
     case 2: {
-        result.nextRepetitionDate = currentDateSTamp + millisecondsPerDay;
+        result.nextRepetitionDate = currentDateStamp + MILLISECONDS_PER_DAY;
         break;
     }
     case 1: {
-        result.nextRepetitionDate = currentDateSTamp
-            + millisecondsPerDay * Math.ceil(result.repetitions ** powerIndexGood);
+        result.nextRepetitionDate = currentDateStamp
+            + MILLISECONDS_PER_DAY * Math.ceil(result.repetitions ** POWER_INDEX_GOOD);
         break;
     }
     case 0: {
-        result.nextRepetitionDate = currentDateSTamp
-            + millisecondsPerDay * Math.ceil(
-                result.repetitions ** powerIndexEasy + result.repetitions,
+        result.nextRepetitionDate = currentDateStamp
+            + MILLISECONDS_PER_DAY * Math.ceil(
+                result.repetitions ** POWER_INDEX_EASY + result.repetitions,
             );
         break;
     }
-    default: result.nextRepetitionDate = currentDateSTamp;
+    default: result.nextRepetitionDate = currentDateStamp;
     }
 
     return result;


### PR DESCRIPTION
At the very start, I thought to use some variation of SuperMemo algo. But deeper I dived into this, the closer I was to the idea, that it is overcomplicated for our case.
So we have simple and understandable getMemoInfo function for providing spaced repetition data.
It takes ```difficulty``` as a required param (according to individual word difficulty for user), quantity of repeats (second param) and return an object with 
1) quantity of repetitions of this word
2) date of the last repetition of this word (actual date)
3) date of the next scheduled repetition

I used timestamps (milliseconds) for any ```Date``` values because it is universal, easy to use for sorting words according to date of next repetition (this way we can prioritize and choose words to repeat at current training), and easy to convert to any other types of ```Date``` representation.

As for the backend, we must add three fields to every word:  repeats, lastDate, nextDate;

I can write some sort of instruction if anyone needs it.