### PR TITLE
ESLINT:  add camelcase rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,8 @@
         "indent": [1, 4],
         "react/jsx-indent": [1, 4],
         "react/jsx-indent-props": [1, 4],
-        "curly": [2, "all"]
+        "curly": [2, "all"],
+        "camelcase": 1
     },
     "parser": "babel-eslint"
 }


### PR DESCRIPTION
Now we have eslint to check our variable naming convention.  The rule is on as a warning. UPPER_SNAKE_CASE allowed only for constants.

https://eslint.org/docs/rules/camelcase - details.

I'll merge this PR tomorrow (Th, July, 2-nd)