### PR TITLE
Default settings template

### DIFF
--- a/src/constants/globalConstants.js
+++ b/src/constants/globalConstants.js
@@ -5,14 +5,20 @@ export const GROUP_COUNT = 6;
 export const PAGE_COUNT = 30;
 export const MEDIA_PREFIX_URL = 'https://raw.githubusercontent.com/aidfromdeagland/rslang-data/master/';
 export const settingsDefault = {
+    wordsPerDay: 20,
     optional: {
-        word: true,
-        textMeaning: true,
-        textExample: true,
-        showPicture: true,
-        showTranscription: true,
-        numberLearnWord: 10,
-        numberLearnCard: 10,
+        totalWords: 20,
+        newWords: 10,
+        showWordTranslate: true,
+        showSentenceMeaning: true,
+        showSentenceExample: true,
+        showWordTranscription: true,
+        showWordImage: true,
+        showSentencesTranslate: true,
+        showAnswerButton: true,
+        showDeleteButton: true,
+        showDifficultButton: true,
+        autoPronunciation: true,
         audioCall: '{modeGame:1,"wordCount":10,"colorStart":{"r":9,"g":44,"b":112},"colorEnd":{"r":224,"g":141,"b":157},"group":0,"page":0}',
     },
 };


### PR DESCRIPTION
change settings template.
pay attention to your settings for minigames: we have already had ~600 chars for our 'optional' field (main app and Audio Call minigame are included), and we have the limit 1500 chars. So (1500 - 600) / 5 = 180 chars for minigame settings.