### PR TITLE
wordServices / getUserAggWords -  add group ignore possibility

### DIFF
--- a/src/services/wordServices.js
+++ b/src/services/wordServices.js
@@ -178,9 +178,11 @@ export class WordService {
         throw new ServiceError(errorText, rawResponse.status);
     }
 
-    static async getUserAggWords(group, filter = '', wordsPerPage = 20) {
-        const url = `${backend}/users/${User.userId}/aggregatedWords`
-            + `?group=${group}&filter=${JSON.stringify(filter)}&wordsPerPage=${wordsPerPage}`;
+    static async getUserAggWords(group = undefined, filter = '', wordsPerPage = 20) {
+        const groupQuery = group === undefined ? '' : `group=${group}&`;
+
+        const url = `${backend}/users/${User.userId}/aggregatedWords?`
+            + `${groupQuery}filter=${JSON.stringify(filter)}&wordsPerPage=${wordsPerPage}`;
         const rawResponse = await fetch(url, {
             method: 'GET',
             withCredentials: true,


### PR DESCRIPTION
I just add the possibility to ignore the group specifying if we pass 'undefined' as the first param. It provides the possibility to get All words, with or without filtering, ignoring group number;